### PR TITLE
feat: Doppler CLI & Playwright browsers; shared path and smoketests (issue #5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,10 +75,10 @@ jobs:
         run: |
           IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:stable
           docker pull ${IMAGE}
-          docker run --rm ${IMAGE} bash -lc "set -euo pipefail; rustc --version; cargo --version; rustfmt --version; cargo clippy -V"
-      
-      - name: Smoke tests (main; non-root 1000:1000)
+          docker run --rm ${IMAGE} bash -lc 'set -euo pipefail; rustc --version; cargo --version; rustfmt --version; cargo clippy -V; command -v doppler && doppler --version; test -d "$PLAYWRIGHT_BROWSERS_PATH" && [ -n "$(ls -A "$PLAYWRIGHT_BROWSERS_PATH")" ]'
+
+      - name: Smoke tests (main; remote image, vscode)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:stable
-          docker run --rm --user 1000:1000 ${IMAGE} bash -lc "set -euo pipefail; rustc --version; cargo --version; rustfmt --version; cargo clippy -V"
+          docker run --rm --user vscode ${IMAGE} bash -lc 'set -euo pipefail; rustc --version; cargo --version; rustfmt --version; cargo clippy -V; command -v doppler && doppler --version >/dev/null; test -r "$PLAYWRIGHT_BROWSERS_PATH" && [ -n "$(ls -A "$PLAYWRIGHT_BROWSERS_PATH")" ]'

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:${PATH}
 
+# Shared Playwright browsers path
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
 # Minimal native build dependencies commonly required by Rust crates
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -18,6 +21,7 @@ RUN apt-get update \
         curl \
         git \
         ca-certificates \
+        gnupg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Rust toolchain (stable) system-wide via rustup and components
@@ -38,6 +42,13 @@ RUN echo 'export PATH=/usr/local/cargo/bin:$PATH' > /etc/profile.d/cargo.sh \
 # - Nightly is not installed by default; use rust-toolchain.toml if needed.
 ########################################
 
+# Install Doppler CLI (system-wide)
+RUN curl -Ls https://cli.doppler.com/install.sh | sh
+
+# Pre-install Playwright browsers (with system deps) into shared path
+RUN npx --yes playwright@latest install --with-deps \
+    && chmod -R a+rx ${PLAYWRIGHT_BROWSERS_PATH}
+
 # Smoketest stage to validate Rust toolchain components exist for root and a non-root user.
 # This stage is built in CI for pull_request events (no docker load/push).
 FROM base AS smoketest
@@ -47,7 +58,11 @@ RUN bash -lc 'set -euo pipefail; \
     command -v rustc >/dev/null && rustc --version; \
     command -v cargo >/dev/null && cargo --version; \
     command -v rustfmt >/dev/null && rustfmt --version; \
-    command -v cargo >/dev/null && cargo clippy -V'
+    command -v cargo >/dev/null && cargo clippy -V; \
+    echo "[smoketest] doppler"; \
+    command -v doppler >/dev/null && doppler --version; \
+    echo "[smoketest] playwright"; \
+    test -d "${PLAYWRIGHT_BROWSERS_PATH}" && [ -n "$(ls -A ${PLAYWRIGHT_BROWSERS_PATH})" ]'
 # Non-root validation with a generic user (no vscode assumption)
 RUN useradd -m -u 10001 -s /bin/bash tester
 USER tester
@@ -57,7 +72,11 @@ RUN bash -lc 'set -euo pipefail; \
     command -v rustc >/dev/null && rustc --version; \
     command -v cargo >/dev/null && cargo --version; \
     command -v rustfmt >/dev/null && rustfmt --version; \
-    command -v cargo >/dev/null && cargo clippy -V'
+    command -v cargo >/dev/null && cargo clippy -V; \
+    echo "[smoketest] doppler (tester)"; \
+    command -v doppler >/dev/null && doppler --version >/dev/null; \
+    echo "[smoketest] playwright (tester)"; \
+    test -r "${PLAYWRIGHT_BROWSERS_PATH}" && [ -n "$(ls -A ${PLAYWRIGHT_BROWSERS_PATH})" ]'
 
 # Default/final image stage should remain last so main builds push the full image
 FROM base AS final

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Overview
 - System-wide install with RUSTUP_HOME=/usr/local/rustup and CARGO_HOME=/usr/local/cargo; PATH includes /usr/local/cargo/bin for all users.
 - Components: rustfmt, clippy, rust-src. Native deps: build-essential, clang, lld, pkg-config, libssl-dev, zlib1g-dev, cmake, curl, git, ca-certificates.
 - Optional utilities: cargo-edit, cargo-nextest.
+ - Includes Doppler CLI and Playwright browsers preinstalled. Browsers are shared at /ms-playwright (PLAYWRIGHT_BROWSERS_PATH) for all users.
 
 Usage
 - Dev Container: set devcontainer.json to use the published image:
@@ -20,3 +21,5 @@ Tags
 Notes
 - Nightly not installed by default; use rust-toolchain.toml if needed.
 - lld installed; consider RUSTFLAGS="-C link-arg=-fuse-ld=lld" per-project.
+ - Doppler CLI is installed via the official install script.
+ - Playwright browsers are installed with --with-deps and shared at /ms-playwright; permissions allow read/execute for non-root users.


### PR DESCRIPTION
Implements issue #5.

Changes
- Dockerfile:
  - Add gnupg.
  - Set ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright.
  - Install Doppler CLI via official shell script.
  - Install Playwright browsers with `--with-deps` and chmod shared path.
  - Extend smoketest stage to validate Doppler and Playwright presence for root and non-root users.
- .github/workflows/build.yml:
  - Extend remote image smoke tests to check Doppler CLI and Playwright browsers for root and `vscode` users.
- README.md:
  - Document inclusion of Doppler CLI and Playwright browsers and shared path.

Notes
- Minimal changes aligned with scope.
- Please monitor CI. If any failures, share the failing job logs and commit SHA 9c328b1 for follow-up.
